### PR TITLE
fixes issue with /etc/ssh/sdm_ca.pub permissions

### DIFF
--- a/onboarding/http/templates/http_install/http_install.tftpl
+++ b/onboarding/http/templates/http_install/http_install.tftpl
@@ -2,6 +2,7 @@
 
 # add sdm public key
 echo "${SSH_PUB_KEY}" | tee -a /etc/ssh/sdm_ca.pub
+chmod 600 /etc/ssh/sdm_ca.pub
 echo "TrustedUserCAKeys /etc/ssh/sdm_ca.pub" | tee -a /etc/ssh/sshd_config
 systemctl restart sshd
 

--- a/onboarding/mysql/templates/mysql_install/mysql_install.tftpl
+++ b/onboarding/mysql/templates/mysql_install/mysql_install.tftpl
@@ -1,5 +1,6 @@
 #!/bin/bash
 echo "${SSH_PUB_KEY}" | tee -a /etc/ssh/sdm_ca.pub
+chmod 600 /etc/ssh/sdm_ca.pub
 echo "TrustedUserCAKeys /etc/ssh/sdm_ca.pub" | tee -a /etc/ssh/sshd_config
 systemctl restart ssh
 


### PR DESCRIPTION
Before this fix it was possible to deploy a server but not be able to connect to it, due ssh ignoring the CA file due to invalid permissions.

The file is being created via the tee -a, so it inherits the default permission mask, which has group/world read in most instances.

This adds a `chmod 600 /etc/ssh/sdm_ca.pub` to both templates to ensure the right permissions are enforced