### PR TITLE
feat: add explicit `vpc_id` and `subnet_ids`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # End of https://www.toptal.com/developers/gitignore/api/terraform
 
 onboarding/.terraform.lock.hcl
+
+.envrc

--- a/onboarding.tf
+++ b/onboarding.tf
@@ -20,6 +20,7 @@ module "strongdm_onboarding" {
 
   # VPC creation takes approximately 5 min
   # If set to false the default VPC will be used instead unless an explicit vpc_id is passed in
+  # optionally subnet_ids can also be added to select a subset of subnets
   # create_vpc = true
 
   # Tags will be added to strongDM and AWS resources.

--- a/onboarding.tf
+++ b/onboarding.tf
@@ -19,7 +19,7 @@ module "strongdm_onboarding" {
   # create_strongdm_gateways = true
 
   # VPC creation takes approximately 5 min
-  # If set to false the default VPC will be used instead
+  # If set to false the default VPC will be used instead unless an explicit vpc_id is passed in
   # create_vpc = true
 
   # Tags will be added to strongDM and AWS resources.

--- a/onboarding/data.tf
+++ b/onboarding/data.tf
@@ -11,9 +11,19 @@ data "aws_vpc" "default" {
 
 data "aws_subnets" "subnets" {
   count = var.create_vpc ? 0 : 1
+
   filter {
     name   = "vpc-id"
     values = [data.aws_vpc.default[0].id]
+  }
+
+  dynamic "filter" {
+    for_each = var.subnet_ids != null ? [true] : []
+
+    content {
+      name   = "subnet-id"
+      values = var.subnet_ids
+    }
   }
 }
 

--- a/onboarding/data.tf
+++ b/onboarding/data.tf
@@ -2,8 +2,11 @@
 # These data-sources gather the necessary VPC information if create VPC is not specified
 # ---------------------------------------------------------------------------- #
 data "aws_vpc" "default" {
-  count   = var.create_vpc ? 0 : 1
-  default = true
+  count = var.create_vpc ? 0 : 1
+
+  id = var.vpc_id
+
+  default = var.vpc_id == null
 }
 
 data "aws_subnets" "subnets" {

--- a/onboarding/variables.tf
+++ b/onboarding/variables.tf
@@ -52,6 +52,12 @@ variable "create_vpc" {
   description = "Set to true to create a VPC to container the resources in this module"
 }
 
+variable "vpc_id" {
+  type        = string
+  default     = null
+  description = "Existing VPC id"
+}
+
 variable "grant_to_existing_users" {
   type        = list(string)
   default     = []

--- a/onboarding/variables.tf
+++ b/onboarding/variables.tf
@@ -58,6 +58,12 @@ variable "vpc_id" {
   description = "Existing VPC id"
 }
 
+variable "subnet_ids" {
+  type        = list(string)
+  default     = null
+  description = "Existing subnet ids"
+}
+
 variable "grant_to_existing_users" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -2,29 +2,33 @@
 variable "SDM_API_ACCESS_KEY" {
   type      = string
   sensitive = true
+  default = null
 }
 
 variable "SDM_API_SECRET_KEY" {
   type      = string
   sensitive = true
+  default = null
 }
 
 variable "SDM_ADMINS_EMAILS" {
   type = string
+  default = null
 }
 
 ### AWS ###
 variable "AWS_ACCESS_KEY_ID" {
   type      = string
   sensitive = true
+  default = null
 }
 
 variable "AWS_SECRET_ACCESS_KEY" {
   type      = string
   sensitive = true
+  default = null
 }
 
 variable "REGION_AWS" {
-  type    = string
-  default = null
+  type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,5 +25,6 @@ variable "AWS_SECRET_ACCESS_KEY" {
 }
 
 variable "REGION_AWS" {
-  type = string
+  type    = string
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,31 +2,26 @@
 variable "SDM_API_ACCESS_KEY" {
   type      = string
   sensitive = true
-  default = null
 }
 
 variable "SDM_API_SECRET_KEY" {
   type      = string
   sensitive = true
-  default = null
 }
 
 variable "SDM_ADMINS_EMAILS" {
   type = string
-  default = null
 }
 
 ### AWS ###
 variable "AWS_ACCESS_KEY_ID" {
   type      = string
   sensitive = true
-  default = null
 }
 
 variable "AWS_SECRET_ACCESS_KEY" {
   type      = string
   sensitive = true
-  default = null
 }
 
 variable "REGION_AWS" {


### PR DESCRIPTION
## what
- Add explicit `vpc_id` and `subnet_ids`

## why
- I want to use an existing networking :)

## example

```hcl
data "aws_vpc" "default" {
  filter {
    name   = "tag:Name"
    values = ["mine"]
  }
}

data "aws_subnets" "default" {
  filter {
    name   = "vpc-id"
    values = [data.aws_vpc.default.id]
  }

  tags = {
    Name = "*rds*"
  }
}

module "strongdm_onboarding" {
  # ...

  create_vpc = false
  vpc_id     = data.aws_vpc.default.id
  subnet_ids = data.aws_subnets.default.ids

  # ...
}
```