### PR TITLE
feat: add `gateway_ingress_ips`

### DIFF
--- a/onboarding.tf
+++ b/onboarding.tf
@@ -22,6 +22,9 @@ module "strongdm_onboarding" {
   # If set to false the default VPC will be used instead
   # create_vpc = true
 
+  # Gateway Ingress IPs default to open to the world.
+  # gateway_ingress_ips = ["0.0.0.0/0"]
+
   # Tags will be added to strongDM and AWS resources.
   # tags = {}
 }

--- a/onboarding/main.tf
+++ b/onboarding/main.tf
@@ -22,10 +22,13 @@ module "sdm" {
   source        = "./sdm_gateway"
   sdm_node_name = "${var.prefix}-gateway"
   deploy_vpc_id = local.vpc_id
+
   gateway_subnet_ids = [
     local.subnet_ids[0],
     local.subnet_ids[1]
   ]
+  gateway_ingress_ips = var.gateway_ingress_ips
+
   tags = merge(local.default_tags, var.tags)
 }
 

--- a/onboarding/sdm_gateway/security_group.tf
+++ b/onboarding/sdm_gateway/security_group.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "this" {
       from_port   = var.gateway_listen_port
       to_port     = var.gateway_listen_port
       protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_blocks = var.gateway_ingress_ips
     }
   }
 

--- a/onboarding/sdm_gateway/variables.tf
+++ b/onboarding/sdm_gateway/variables.tf
@@ -17,6 +17,13 @@ variable "gateway_subnet_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "gateway_ingress_ips" {
+  description = "A list of ingress IPs"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "relay_subnet_ids" {
   description = "strongDM relays will be deployed into subnets provided"
   type        = list(string)

--- a/onboarding/variables.tf
+++ b/onboarding/variables.tf
@@ -70,6 +70,12 @@ variable "read_only_users" {
   description = "A list of email addresses that will receive read only access."
 }
 
+variable "gateway_ingress_ips" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "A list of ingress IPs"
+}
+
 locals {
   vpc_id     = var.create_vpc ? module.network[0].vpc_id : data.aws_vpc.default[0].id
   subnet_ids = var.create_vpc ? module.network[0].public_subnets : sort(data.aws_subnets.subnets[0].ids)


### PR DESCRIPTION
## what
- Add `gateway_ingress_ips`

## why
- I want to only allow the gateway access to a VPN IP address instead of the whole world