### PR TITLE
feat: add permit-everything policy

### DIFF
--- a/onboarding/main.tf
+++ b/onboarding/main.tf
@@ -82,3 +82,12 @@ module "http_website" {
   admins_id      = sdm_role.admins.id
   read_only_id   = sdm_role.read_only.id
 }
+
+resource "sdm_policy" "permit_everything" {
+  name        = "permit-everything"
+  description = "Permits everything"
+
+  policy = <<EOP
+permit(principal, action, resource);
+EOP
+}

--- a/onboarding/main.tf
+++ b/onboarding/main.tf
@@ -84,6 +84,8 @@ module "http_website" {
 }
 
 resource "sdm_policy" "permit_everything" {
+  count = var.create_sdm_policy_permit_everything ? 1 : 0
+
   name        = "permit-everything"
   description = "Permits everything"
 

--- a/onboarding/variables.tf
+++ b/onboarding/variables.tf
@@ -52,6 +52,12 @@ variable "create_vpc" {
   description = "Set to true to create a VPC to container the resources in this module"
 }
 
+variable "create_sdm_policy_permit_everything" {
+  type        = bool
+  default     = false
+  description = "Set to true to create a default policy to permit everything"
+}
+
 variable "grant_to_existing_users" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
- feat: add permit-everything policy

## why
- This is needed to setup the onboarding module or the new users will not have access to various resources

## references
- https://registry.terraform.io/providers/strongdm/sdm/latest/docs/resources/policy#example-usage